### PR TITLE
[WIP] Support for java.nio.file.SystemWatcher for file/directory watching events

### DIFF
--- a/src/main/scala/monix/nio/WatchService.scala
+++ b/src/main/scala/monix/nio/WatchService.scala
@@ -1,0 +1,12 @@
+package monix.nio
+
+import java.nio.file.WatchKey
+import monix.eval.Task
+import scala.concurrent.duration.TimeUnit
+
+private[nio] trait WatchService {
+  def poll(timeout: Long, timeUnit: TimeUnit): Task[Option[WatchKey]]
+  def poll(): Task[Option[WatchKey]]
+  def take(): Task[WatchKey]
+  def close(): Task[Unit]
+}

--- a/src/main/scala/monix/nio/WatchServiceObservable.scala
+++ b/src/main/scala/monix/nio/WatchServiceObservable.scala
@@ -1,0 +1,75 @@
+package monix.nio
+
+import java.nio.file.WatchEvent
+
+import monix.eval.{Callback, Task}
+import monix.execution.Ack.{Continue, Stop}
+import monix.execution.atomic.Atomic
+import monix.execution.cancelables.SingleAssignmentCancelable
+import monix.execution.exceptions.APIContractViolationException
+import monix.execution.{Cancelable, Scheduler}
+import monix.reactive.Observable
+import monix.reactive.observers.Subscriber
+
+import scala.concurrent.Future
+import scala.util.control.NonFatal
+
+abstract class WatchServiceObservable extends Observable[WatchEvent[_]] {
+  def watchService: Option[WatchService]
+
+  private[this] val wasSubscribed = Atomic(false)
+  override def unsafeSubscribeFn(subscriber: Subscriber[WatchEvent[_]]): Cancelable = {
+    if (wasSubscribed.getAndSet(true)) {
+      subscriber.onError(APIContractViolationException(this.getClass.getName))
+      Cancelable.empty
+    } else try startPolling(subscriber) catch {
+      case NonFatal(e) =>
+        subscriber.onError(e)
+        Cancelable.empty
+    }
+  }
+
+  def init(subscriber: Subscriber[WatchEvent[_]]): Future[Unit] =
+    Future.successful(())
+
+  private def startPolling(subscriber: Subscriber[WatchEvent[_]]): Cancelable = {
+    import subscriber.scheduler
+
+    val taskCallback = new Callback[WatchEvent[_]]() {
+      override def onSuccess(value: WatchEvent[_]): Unit = {}
+      override def onError(ex: Throwable): Unit = {
+        subscriber.onError(ex)
+      }
+    }
+    val cancelable = Task
+      .fromFuture(init(subscriber))
+      .flatMap { _ =>
+        loop(subscriber)
+      }
+      .executeWithOptions(_.enableAutoCancelableRunLoops)
+      .runAsync(taskCallback)
+
+    val extraCancelable = Cancelable(() => {
+      cancelable.cancel()
+    })
+    SingleAssignmentCancelable.plusOne(extraCancelable)
+  }
+
+  private def loop(subscriber: Subscriber[WatchEvent[_]])(implicit scheduler: Scheduler): Task[WatchEvent[_]] = {
+    import collection.JavaConverters._
+    watchService.map { ws =>
+      ws.take().map { key =>
+        key.pollEvents().asScala foreach { event =>
+          Task.fromFuture(subscriber.onNext(event)).flatMap {
+            case Continue => loop(subscriber)
+            case Stop => emptyTask
+          }
+        }
+        key.reset()
+      }
+      emptyTask
+    }
+  }.getOrElse(emptyTask)
+
+  private val emptyTask: Task[WatchEvent[_]] = Task.create[WatchEvent[_]]((_, _) => Cancelable.empty)
+}

--- a/src/main/scala/monix/nio/WatchServiceObservable.scala
+++ b/src/main/scala/monix/nio/WatchServiceObservable.scala
@@ -2,23 +2,23 @@ package monix.nio
 
 import java.nio.file.WatchEvent
 
-import monix.eval.{Callback, Task}
-import monix.execution.Ack.{Continue, Stop}
+import monix.eval.{ Callback, Task }
+import monix.execution.Ack.{ Continue, Stop }
 import monix.execution.atomic.Atomic
 import monix.execution.cancelables.SingleAssignmentCancelable
 import monix.execution.exceptions.APIContractViolationException
-import monix.execution.{Cancelable, Scheduler}
+import monix.execution.{ Cancelable, Scheduler }
 import monix.reactive.Observable
 import monix.reactive.observers.Subscriber
 
 import scala.concurrent.Future
 import scala.util.control.NonFatal
 
-abstract class WatchServiceObservable extends Observable[WatchEvent[_]] {
+abstract class WatchServiceObservable extends Observable[Array[WatchEvent[_]]] {
   def watchService: Option[WatchService]
 
   private[this] val wasSubscribed = Atomic(false)
-  override def unsafeSubscribeFn(subscriber: Subscriber[WatchEvent[_]]): Cancelable = {
+  override def unsafeSubscribeFn(subscriber: Subscriber[Array[WatchEvent[_]]]): Cancelable = {
     if (wasSubscribed.getAndSet(true)) {
       subscriber.onError(APIContractViolationException(this.getClass.getName))
       Cancelable.empty
@@ -29,14 +29,14 @@ abstract class WatchServiceObservable extends Observable[WatchEvent[_]] {
     }
   }
 
-  def init(subscriber: Subscriber[WatchEvent[_]]): Future[Unit] =
+  def init(subscriber: Subscriber[Array[WatchEvent[_]]]): Future[Unit] =
     Future.successful(())
 
-  private def startPolling(subscriber: Subscriber[WatchEvent[_]]): Cancelable = {
+  private def startPolling(subscriber: Subscriber[Array[WatchEvent[_]]]): Cancelable = {
     import subscriber.scheduler
 
-    val taskCallback = new Callback[WatchEvent[_]]() {
-      override def onSuccess(value: WatchEvent[_]): Unit = {}
+    val taskCallback = new Callback[Array[WatchEvent[_]]]() {
+      override def onSuccess(value: Array[WatchEvent[_]]): Unit = {}
       override def onError(ex: Throwable): Unit = {
         subscriber.onError(ex)
       }
@@ -55,21 +55,21 @@ abstract class WatchServiceObservable extends Observable[WatchEvent[_]] {
     SingleAssignmentCancelable.plusOne(extraCancelable)
   }
 
-  private def loop(subscriber: Subscriber[WatchEvent[_]])(implicit scheduler: Scheduler): Task[WatchEvent[_]] = {
+  private def loop(subscriber: Subscriber[Array[WatchEvent[_]]])(implicit scheduler: Scheduler): Task[Array[WatchEvent[_]]] = {
     import collection.JavaConverters._
     watchService.map { ws =>
-      ws.take().map { key =>
-        key.pollEvents().asScala foreach { event =>
-          Task.fromFuture(subscriber.onNext(event)).flatMap {
+      ws.take()
+        .doOnCancel(Task.defer(ws.close()))
+        .flatMap { key =>
+          val events = key.pollEvents().asScala.toArray
+          key.reset()
+          Task.fromFuture(subscriber.onNext(events)).flatMap {
             case Continue => loop(subscriber)
             case Stop => emptyTask
           }
         }
-        key.reset()
       }
-      emptyTask
-    }
-  }.getOrElse(emptyTask)
+    }.getOrElse(emptyTask)
 
-  private val emptyTask: Task[WatchEvent[_]] = Task.create[WatchEvent[_]]((_, _) => Cancelable.empty)
+  private val emptyTask = Task.create[Array[WatchEvent[_]]]((_, _) => Cancelable.empty)
 }

--- a/src/main/scala/monix/nio/file/AsyncWatchServiceObservable.scala
+++ b/src/main/scala/monix/nio/file/AsyncWatchServiceObservable.scala
@@ -20,5 +20,3 @@ final class AsyncWatchServiceObservable(taskWatchService: TaskWatchService) exte
   }
 }
 
-
-

--- a/src/main/scala/monix/nio/file/AsyncWatchServiceObservable.scala
+++ b/src/main/scala/monix/nio/file/AsyncWatchServiceObservable.scala
@@ -1,0 +1,24 @@
+package monix.nio.file
+
+import java.nio.file.WatchKey
+
+import monix.eval.Task
+import monix.nio.WatchServiceObservable
+
+import scala.concurrent.duration.TimeUnit
+
+final class AsyncWatchServiceObservable(taskWatchService: TaskWatchService) extends WatchServiceObservable {
+  override def watchService = Option {
+    asyncWatchServiceWrapper(taskWatchService)
+  }
+
+  private[file] def asyncWatchServiceWrapper(taskWatchService: TaskWatchService) = new monix.nio.WatchService {
+    override def poll(timeout: Long, timeUnit: TimeUnit): Task[Option[WatchKey]] = taskWatchService.poll(timeout, timeUnit)
+    override def poll(): Task[Option[WatchKey]] = taskWatchService.poll()
+    override def take(): Task[WatchKey] = taskWatchService.take()
+    override def close(): Task[Unit] = taskWatchService.close()
+  }
+}
+
+
+

--- a/src/main/scala/monix/nio/file/TaskWatchService.scala
+++ b/src/main/scala/monix/nio/file/TaskWatchService.scala
@@ -1,9 +1,9 @@
 package monix.nio.file
 
 import java.nio.file.WatchEvent.Kind
-import java.nio.file.{Path, WatchKey}
+import java.nio.file.{ Path, WatchKey }
 
-import monix.eval.{Callback, Task}
+import monix.eval.{ Callback, Task }
 import monix.execution.Scheduler
 
 import scala.concurrent.duration.TimeUnit

--- a/src/main/scala/monix/nio/file/TaskWatchService.scala
+++ b/src/main/scala/monix/nio/file/TaskWatchService.scala
@@ -1,0 +1,52 @@
+package monix.nio.file
+
+import java.nio.file.WatchEvent.Kind
+import java.nio.file.{Path, WatchKey}
+
+import monix.eval.{Callback, Task}
+import monix.execution.Scheduler
+
+import scala.concurrent.duration.TimeUnit
+
+/**
+  * A `Task` based watch service that watches registered objects for changes and events. For example a file manager may use a watch service
+  * to monitor a directory for changes so that it can update its display of the list of files when files are created or deleted.
+  *
+  * On the JVM this is a wrapper around
+  * [[https://docs.oracle.com/javase/8/docs/api/java/nio/channels/AsynchronousFileChannel.html java.nio.file.WatchService]]
+  * (class available since Java 7 for registering objects for changes and events).
+  *
+  */
+abstract class TaskWatchService {
+
+  protected val watchService: WatchService
+
+  def poll(timeout: Long, timeUnit: TimeUnit): Task[Option[WatchKey]] = {
+    Task.unsafeCreate { (context, cb) =>
+      implicit val s = context.scheduler
+      watchService.poll(timeout, timeUnit, Callback.async(cb))
+    }
+  }
+
+  def poll(): Task[Option[WatchKey]] = {
+    Task.unsafeCreate { (context, cb) =>
+      implicit val s = context.scheduler
+      watchService.poll(Callback.async(cb))
+    }
+  }
+
+  def take(): Task[WatchKey] = {
+    Task.unsafeCreate { (context, cb) =>
+      implicit val s = context.scheduler
+      watchService.take(Callback.async(cb))
+    }
+  }
+}
+
+object TaskWatchService {
+  def apply(path: Path, events: Kind[_]*)(implicit s: Scheduler): TaskWatchService = {
+    new TaskWatchService {
+      override val watchService: WatchService = WatchService.apply(path, events: _*)
+    }
+  }
+}

--- a/src/main/scala/monix/nio/file/TaskWatchService.scala
+++ b/src/main/scala/monix/nio/file/TaskWatchService.scala
@@ -41,6 +41,9 @@ abstract class TaskWatchService {
       watchService.take(Callback.async(cb))
     }
   }
+
+  def close(): Task[Unit] =
+    Task.now(watchService.close())
 }
 
 object TaskWatchService {

--- a/src/main/scala/monix/nio/file/WatchService.scala
+++ b/src/main/scala/monix/nio/file/WatchService.scala
@@ -1,0 +1,104 @@
+package monix.nio.file
+
+import java.nio.file.StandardWatchEventKinds.{ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY}
+import java.nio.file.WatchEvent.Kind
+import java.nio.file.{Path, WatchEvent, WatchKey}
+
+import com.sun.nio.file.SensitivityWatchEventModifier
+import monix.eval.Callback
+import monix.execution.{Cancelable, Scheduler}
+
+import scala.concurrent.{Future, Promise}
+import scala.concurrent.duration.TimeUnit
+import scala.util.control.NonFatal
+
+/**
+  * A watch service that watches registered objects for changes and events. For example a file manager may use a watch service
+  * to monitor a directory for changes so that it can update its display of the list of files when files are created or deleted.
+  *
+  * On the JVM this is a wrapper around
+  * [[https://docs.oracle.com/javase/8/docs/api/java/nio/channels/AsynchronousFileChannel.html java.nio.file.WatchService]]
+  * (class available since Java 7 for registering objects for changes and events).
+  *
+  */
+abstract class WatchService extends AutoCloseable {
+  def poll(timeout: Long, timeUnit: TimeUnit, cb: Callback[Option[WatchKey]]): Unit
+
+  def poll(timeout: Long, timeUnit: TimeUnit): Future[Option[WatchKey]] = {
+    val p = Promise[Option[WatchKey]]()
+    poll(timeout, timeUnit, Callback.fromPromise(p))
+    p.future
+  }
+
+  def poll(cb: Callback[Option[WatchKey]]): Unit
+
+  def poll(): Future[Option[WatchKey]] = {
+    val p = Promise[Option[WatchKey]]()
+    poll(Callback.fromPromise(p))
+    p.future
+  }
+
+  def take(cb: Callback[WatchKey]): Unit
+
+  def take(): Future[WatchKey] = {
+    val p = Promise[WatchKey]()
+    take(Callback.fromPromise(p))
+    p.future
+  }
+}
+
+object WatchService {
+  val SupportedEvents: Set[Kind[_]] = Set(ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY)
+
+  def apply(path: Path, events: Kind[_]*)(implicit scheduler: Scheduler): WatchService = {
+    val watcher = path.getFileSystem.newWatchService()
+    val watchFor = if (events.isEmpty) SupportedEvents else events
+
+    path.register(watcher,
+      watchFor.toArray,
+      SensitivityWatchEventModifier.HIGH.asInstanceOf[WatchEvent.Modifier])
+
+    new NIOWatcherServiceImplementation(watcher)
+  }
+
+  private final class NIOWatcherServiceImplementation(watcher: java.nio.file.WatchService)(implicit scheduler: Scheduler) extends WatchService {
+    override def poll(timeout: Long, timeUnit: TimeUnit, cb: Callback[Option[WatchKey]]): Unit = {
+      try {
+        val key = Option(watcher.poll(timeout, timeUnit))
+        cb.onSuccess(key)
+      } catch {
+        case NonFatal(ex) =>
+          cb.onError(ex)
+      }
+    }
+
+    override def poll(cb: Callback[Option[WatchKey]]): Unit = {
+      try {
+        val key = Option(watcher.poll())
+        cb.onSuccess(key)
+      } catch {
+        case NonFatal(ex) =>
+          cb.onError(ex)
+      }
+    }
+
+    override def take(cb: Callback[WatchKey]): Unit = {
+      try {
+        val key = watcher.take()
+        cb.onSuccess(key)
+      } catch {
+        case NonFatal(ex) =>
+          cb.onError(ex)
+      }
+    }
+
+    override def close(): Unit = cancelable.cancel()
+
+    private[this] val cancelable: Cancelable =
+      Cancelable { () =>
+        try watcher.close() catch {
+          case NonFatal(ex) => scheduler.reportFailure(ex)
+        }
+      }
+  }
+}

--- a/src/main/scala/monix/nio/file/WatchService.scala
+++ b/src/main/scala/monix/nio/file/WatchService.scala
@@ -1,14 +1,14 @@
 package monix.nio.file
 
-import java.nio.file.StandardWatchEventKinds.{ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY}
+import java.nio.file.StandardWatchEventKinds.{ ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY }
 import java.nio.file.WatchEvent.Kind
-import java.nio.file.{Path, WatchEvent, WatchKey}
+import java.nio.file.{ Path, WatchEvent, WatchKey }
 
 import com.sun.nio.file.SensitivityWatchEventModifier
 import monix.eval.Callback
-import monix.execution.{Cancelable, Scheduler}
+import monix.execution.{ Cancelable, Scheduler }
 
-import scala.concurrent.{Future, Promise}
+import scala.concurrent.{ Future, Promise }
 import scala.concurrent.duration.TimeUnit
 import scala.util.control.NonFatal
 
@@ -54,9 +54,11 @@ object WatchService {
     val watcher = path.getFileSystem.newWatchService()
     val watchFor = if (events.isEmpty) SupportedEvents else events
 
-    path.register(watcher,
+    path.register(
+      watcher,
       watchFor.toArray,
-      SensitivityWatchEventModifier.HIGH.asInstanceOf[WatchEvent.Modifier])
+      SensitivityWatchEventModifier.HIGH.asInstanceOf[WatchEvent.Modifier]
+    )
 
     new NIOWatcherServiceImplementation(watcher)
   }

--- a/src/main/scala/monix/nio/file/file.scala
+++ b/src/main/scala/monix/nio/file/file.scala
@@ -18,7 +18,8 @@
 package monix.nio
 
 import java.nio.ByteBuffer
-import java.nio.file.{ Path, StandardOpenOption }
+import java.nio.file.WatchEvent.Kind
+import java.nio.file.{Path, StandardOpenOption}
 
 import monix.execution.Scheduler
 
@@ -47,6 +48,14 @@ package object file {
     val flagsWithWriteOptions = flags :+ StandardOpenOption.WRITE :+ StandardOpenOption.CREATE
     val channel = TaskFileChannel(path.toFile, flagsWithWriteOptions: _*)
     new AsyncFileChannelConsumer(channel, startPosition)
+  }
+
+  def watchAsync(
+    path: Path,
+    events: Seq[Kind[_]] = Seq.empty
+  )(implicit s: Scheduler):  WatchServiceObservable = {
+    val watcher = TaskWatchService(path, events: _*)
+    new AsyncWatchServiceObservable(watcher)
   }
 
   private[file] def asyncChannelWrapper(taskFileChannel: TaskFileChannel) = new AsyncChannel {

--- a/src/main/scala/monix/nio/file/file.scala
+++ b/src/main/scala/monix/nio/file/file.scala
@@ -19,7 +19,7 @@ package monix.nio
 
 import java.nio.ByteBuffer
 import java.nio.file.WatchEvent.Kind
-import java.nio.file.{Path, StandardOpenOption}
+import java.nio.file.{ Path, StandardOpenOption }
 
 import monix.execution.Scheduler
 
@@ -53,7 +53,7 @@ package object file {
   def watchAsync(
     path: Path,
     events: Seq[Kind[_]] = Seq.empty
-  )(implicit s: Scheduler):  WatchServiceObservable = {
+  )(implicit s: Scheduler): WatchServiceObservable = {
     val watcher = TaskWatchService(path, events: _*)
     new AsyncWatchServiceObservable(watcher)
   }

--- a/src/test/scala/monix/nio/file/WatchServiceTest.scala
+++ b/src/test/scala/monix/nio/file/WatchServiceTest.scala
@@ -1,0 +1,18 @@
+package monix.nio.file
+
+import java.nio.file.{Paths, WatchEvent}
+
+object MyApp extends App {
+  implicit val ctx = monix.execution.Scheduler.Implicits.global
+
+  val path = Paths.get("/tmp")
+
+  def printEvent(event: WatchEvent[_]): Unit = {
+    val name = event.context().toString
+    val fullPath = path.resolve(name)
+    println(s"${event.kind().name()} - $fullPath")
+  }
+
+  watchAsync(path)
+    .foreach(p => p.foreach(printEvent))
+}


### PR DESCRIPTION
I started playing around with Monix today and got inspired to try to wrap the System Watcher.

I've added a helper method `watchAsync` that takes in a `Path` and optional arguments to specify what events to watch for. The observable receives an `Array[WatchEvent[_]]`.

Here's the simplest use case:

```scala
implicit val ctx = monix.execution.Scheduler.Implicits.global

val path = Paths.get("/tmp")

def printEvent(event: WatchEvent[_]): Unit = {
  val name = event.context().toString
  val fullPath = path.resolve(name)
  println(s"${event.kind().name()} - $fullPath")
}

watchAsync(path)
  .foreach(p => p.foreach(printEvent))
```

Will output (for a newly created, then deleted file):

```
ENTRY_CREATE - /tmp/hello-world.txt
ENTRY_DELETE - /tmp/hello-world.txt
```

Obviously it borrows heavily from an existing implementation of AsyncChannel. Any comments are welcomed!
Still need to create proper test cases.