### PR TITLE
Upgrade to Monix 3.0.0-RC2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ import sbtrelease.{Version, versionFormatError}
 
 addCommandAlias("release", ";+publishSigned ;sonatypeReleaseAll")
 
-val monixVersion = "3.0.0-M3"
+val monixVersion = "3.0.0-RC2"
 
 val appSettings = Seq(
   name := "monix-nio",

--- a/src/main/scala/monix/nio/AsyncChannelConsumer.scala
+++ b/src/main/scala/monix/nio/AsyncChannelConsumer.scala
@@ -19,14 +19,14 @@ package monix.nio
 
 import java.nio.ByteBuffer
 
-import monix.execution.Ack.{Continue, Stop}
-import monix.execution.{Ack, Callback, Cancelable, Scheduler}
+import monix.execution.Ack.{ Continue, Stop }
+import monix.execution.{ Ack, Callback, Cancelable, Scheduler }
 import monix.execution.atomic.Atomic
-import monix.execution.cancelables.{AssignableCancelable, SingleAssignCancelable}
+import monix.execution.cancelables.{ AssignableCancelable, SingleAssignCancelable }
 import monix.reactive.Consumer
 import monix.reactive.observers.Subscriber
 
-import scala.concurrent.{Future, Promise}
+import scala.concurrent.{ Future, Promise }
 import scala.util.control.NonFatal
 
 private[nio] abstract class AsyncChannelConsumer extends Consumer[Array[Byte], Long] {

--- a/src/main/scala/monix/nio/AsyncChannelConsumer.scala
+++ b/src/main/scala/monix/nio/AsyncChannelConsumer.scala
@@ -19,15 +19,14 @@ package monix.nio
 
 import java.nio.ByteBuffer
 
-import monix.eval.Callback
-import monix.execution.Ack.{ Continue, Stop }
-import monix.execution.{ Ack, Cancelable, Scheduler }
+import monix.execution.Ack.{Continue, Stop}
+import monix.execution.{Ack, Callback, Cancelable, Scheduler}
 import monix.execution.atomic.Atomic
-import monix.execution.cancelables.{ AssignableCancelable, SingleAssignCancelable }
+import monix.execution.cancelables.{AssignableCancelable, SingleAssignCancelable}
 import monix.reactive.Consumer
 import monix.reactive.observers.Subscriber
 
-import scala.concurrent.{ Future, Promise }
+import scala.concurrent.{Future, Promise}
 import scala.util.control.NonFatal
 
 private[nio] abstract class AsyncChannelConsumer extends Consumer[Array[Byte], Long] {
@@ -35,7 +34,7 @@ private[nio] abstract class AsyncChannelConsumer extends Consumer[Array[Byte], L
   def withInitialPosition: Long = 0l
   def init(subscriber: AsyncChannelSubscriber): Future[Unit] = Future.successful(())
 
-  class AsyncChannelSubscriber(consumerCallback: Callback[Long])(implicit val scheduler: Scheduler)
+  class AsyncChannelSubscriber(consumerCallback: Callback[Throwable, Long])(implicit val scheduler: Scheduler)
     extends Subscriber[Array[Byte]] { self =>
 
     private[this] lazy val initFuture = init(self)
@@ -50,7 +49,7 @@ private[nio] abstract class AsyncChannelConsumer extends Consumer[Array[Byte], L
             sc
               .write(ByteBuffer.wrap(elem), position)
               .runAsync(
-                new Callback[Int] {
+                new Callback[Throwable, Int] {
                   override def onError(exc: Throwable) = {
                     closeChannel()
                     sendError(exc)
@@ -103,10 +102,10 @@ private[nio] abstract class AsyncChannelConsumer extends Consumer[Array[Byte], L
       }
 
     private[nio] final def closeChannel()(implicit scheduler: Scheduler) =
-      channel.foreach(_.close().runAsync)
+      channel.foreach(_.close().runToFuture)
   }
 
-  override def createSubscriber(cb: Callback[Long], s: Scheduler): (Subscriber[Array[Byte]], AssignableCancelable) = {
+  override def createSubscriber(cb: Callback[Throwable, Long], s: Scheduler): (Subscriber[Array[Byte]], AssignableCancelable) = {
     val out = new AsyncChannelSubscriber(cb)(s)
 
     val extraCancelable = Cancelable(() => out.onCancel())

--- a/src/main/scala/monix/nio/AsyncChannelObservable.scala
+++ b/src/main/scala/monix/nio/AsyncChannelObservable.scala
@@ -20,12 +20,12 @@ package monix.nio
 import java.nio.ByteBuffer
 
 import monix.eval.Task
-import monix.execution.Ack.{Continue, Stop}
-import monix.execution.{Callback, Cancelable, Scheduler}
+import monix.execution.Ack.{ Continue, Stop }
+import monix.execution.{ Callback, Cancelable, Scheduler }
 import monix.execution.atomic.Atomic
 import monix.execution.cancelables.SingleAssignCancelable
 import monix.execution.exceptions.APIContractViolationException
-import monix.nio.internal.{Bytes, EmptyBytes, NonEmptyBytes}
+import monix.nio.internal.{ Bytes, EmptyBytes, NonEmptyBytes }
 import monix.reactive.Observable
 import monix.reactive.observers.Subscriber
 

--- a/src/main/scala/monix/nio/AsyncChannelObservable.scala
+++ b/src/main/scala/monix/nio/AsyncChannelObservable.scala
@@ -19,13 +19,13 @@ package monix.nio
 
 import java.nio.ByteBuffer
 
-import monix.eval.{ Callback, Task }
-import monix.execution.Ack.{ Continue, Stop }
-import monix.execution.{ Cancelable, Scheduler }
+import monix.eval.Task
+import monix.execution.Ack.{Continue, Stop}
+import monix.execution.{Callback, Cancelable, Scheduler}
 import monix.execution.atomic.Atomic
 import monix.execution.cancelables.SingleAssignCancelable
 import monix.execution.exceptions.APIContractViolationException
-import monix.nio.internal.{ Bytes, EmptyBytes, NonEmptyBytes }
+import monix.nio.internal.{Bytes, EmptyBytes, NonEmptyBytes}
 import monix.reactive.Observable
 import monix.reactive.observers.Subscriber
 
@@ -55,7 +55,7 @@ private[nio] abstract class AsyncChannelObservable extends Observable[Array[Byte
   private def startReading(subscriber: Subscriber[Array[Byte]]): Cancelable = {
     import subscriber.scheduler
 
-    val taskCallback = new Callback[Array[Byte]]() {
+    val taskCallback = new Callback[Throwable, Array[Byte]]() {
       override def onSuccess(value: Array[Byte]): Unit = {
         channel.collect { case sc if sc.closeOnComplete => closeChannel() }
       }
@@ -107,5 +107,5 @@ private[nio] abstract class AsyncChannelObservable extends Observable[Array[Byte
   }
 
   private[nio] final def closeChannel()(implicit scheduler: Scheduler) =
-    channel.foreach(_.close().runAsync)
+    channel.foreach(_.close().runToFuture)
 }

--- a/src/main/scala/monix/nio/WatchServiceObservable.scala
+++ b/src/main/scala/monix/nio/WatchServiceObservable.scala
@@ -3,11 +3,11 @@ package monix.nio
 import java.nio.file.WatchEvent
 
 import monix.eval.Task
-import monix.execution.Ack.{Continue, Stop}
+import monix.execution.Ack.{ Continue, Stop }
 import monix.execution.atomic.Atomic
 import monix.execution.cancelables.SingleAssignCancelable
 import monix.execution.exceptions.APIContractViolationException
-import monix.execution.{Callback, Cancelable, Scheduler}
+import monix.execution.{ Callback, Cancelable, Scheduler }
 import monix.reactive.Observable
 import monix.reactive.observers.Subscriber
 

--- a/src/main/scala/monix/nio/WatchServiceObservable.scala
+++ b/src/main/scala/monix/nio/WatchServiceObservable.scala
@@ -2,12 +2,12 @@ package monix.nio
 
 import java.nio.file.WatchEvent
 
-import monix.eval.{ Callback, Task }
-import monix.execution.Ack.{ Continue, Stop }
+import monix.eval.Task
+import monix.execution.Ack.{Continue, Stop}
 import monix.execution.atomic.Atomic
 import monix.execution.cancelables.SingleAssignCancelable
 import monix.execution.exceptions.APIContractViolationException
-import monix.execution.{ Cancelable, Scheduler }
+import monix.execution.{Callback, Cancelable, Scheduler}
 import monix.reactive.Observable
 import monix.reactive.observers.Subscriber
 
@@ -35,7 +35,7 @@ abstract class WatchServiceObservable extends Observable[Array[WatchEvent[_]]] {
   private def startPolling(subscriber: Subscriber[Array[WatchEvent[_]]]): Cancelable = {
     import subscriber.scheduler
 
-    val taskCallback = new Callback[Array[WatchEvent[_]]]() {
+    val taskCallback = new Callback[Throwable, Array[WatchEvent[_]]]() {
       override def onSuccess(value: Array[WatchEvent[_]]): Unit = {}
       override def onError(ex: Throwable): Unit = {
         subscriber.onError(ex)

--- a/src/main/scala/monix/nio/benchmarks/ReadWriteFileBenchmark.scala
+++ b/src/main/scala/monix/nio/benchmarks/ReadWriteFileBenchmark.scala
@@ -73,7 +73,7 @@ class ReadWriteFileBenchmark {
     val program = Observable
       .fromIterable(chunks1)
       .consumeWith(writeAsync(to))
-    Await.result(program.runAsync, Duration.Inf)
+    Await.result(program.runToFuture, Duration.Inf)
   }
 
   @Benchmark
@@ -82,7 +82,7 @@ class ReadWriteFileBenchmark {
     val program = Observable
       .fromIterable(chunks100)
       .consumeWith(writeAsync(to))
-    Await.result(program.runAsync, Duration.Inf)
+    Await.result(program.runToFuture, Duration.Inf)
   }
 
   @Benchmark
@@ -91,7 +91,7 @@ class ReadWriteFileBenchmark {
     val program = Observable
       .fromIterable(chunks1000)
       .consumeWith(writeAsync(to))
-    Await.result(program.runAsync, Duration.Inf)
+    Await.result(program.runToFuture, Duration.Inf)
   }
 
   @Benchmark
@@ -100,7 +100,7 @@ class ReadWriteFileBenchmark {
     val program = Observable
       .fromIterable(List(rawBytes))
       .consumeWith(writeAsync(to))
-    Await.result(program.runAsync, Duration.Inf)
+    Await.result(program.runToFuture, Duration.Inf)
   }
 
   @Benchmark

--- a/src/main/scala/monix/nio/file/AsyncFileChannel.scala
+++ b/src/main/scala/monix/nio/file/AsyncFileChannel.scala
@@ -19,13 +19,13 @@ package monix.nio.file
 
 import java.io.File
 import java.nio.ByteBuffer
-import java.nio.channels.{AsynchronousFileChannel, CompletionHandler}
+import java.nio.channels.{ AsynchronousFileChannel, CompletionHandler }
 import java.nio.file.StandardOpenOption
 
-import monix.execution.{Callback, Cancelable, Scheduler}
+import monix.execution.{ Callback, Cancelable, Scheduler }
 import monix.nio.internal.ExecutorServiceWrapper
 
-import scala.concurrent.{Future, Promise}
+import scala.concurrent.{ Future, Promise }
 import scala.concurrent.blocking
 import scala.util.control.NonFatal
 

--- a/src/main/scala/monix/nio/file/TaskFileChannel.scala
+++ b/src/main/scala/monix/nio/file/TaskFileChannel.scala
@@ -4,8 +4,8 @@ import java.io.File
 import java.nio.ByteBuffer
 import java.nio.file.StandardOpenOption
 
-import monix.eval.{ Callback, Task }
-import monix.execution.{ Cancelable, Scheduler }
+import monix.eval.Task
+import monix.execution.{ Callback, Scheduler }
 
 /**
   * A `Task` based asynchronous channel for reading, writing, and manipulating a file.
@@ -81,9 +81,9 @@ abstract class TaskFileChannel {
 
   /** $sizeDesc */
   def size: Task[Long] =
-    Task.unsafeCreate { (context, cb) =>
-      implicit val s = context.scheduler
-      asyncFileChannel.size(Callback.async(cb))
+    Task.create { (scheduler, cb) =>
+      implicit val s = scheduler
+      asyncFileChannel.size(Callback.forked(cb))
     }
 
   /**
@@ -95,9 +95,9 @@ abstract class TaskFileChannel {
     * @return $readReturnDesc
     */
   def read(dst: ByteBuffer, position: Long): Task[Int] =
-    Task.unsafeCreate { (context, cb) =>
-      implicit val s = context.scheduler
-      asyncFileChannel.read(dst, position, Callback.async(cb))
+    Task.create { (scheduler, cb) =>
+      implicit val s = scheduler
+      asyncFileChannel.read(dst, position, Callback.forked(cb))
     }
 
   /**
@@ -109,9 +109,9 @@ abstract class TaskFileChannel {
     * @return $writeReturnDesc
     */
   def write(src: ByteBuffer, position: Long): Task[Int] =
-    Task.unsafeCreate { (context, cb) =>
-      implicit val s = context.scheduler
-      asyncFileChannel.write(src, position, Callback.async(cb))
+    Task.create { (scheduler, cb) =>
+      implicit val s = scheduler
+      asyncFileChannel.write(src, position, Callback.forked(cb))
     }
 
   /**
@@ -120,9 +120,9 @@ abstract class TaskFileChannel {
     * @param writeMetaData $flushWriteMetaDesc
     */
   def flush(writeMetaData: Boolean): Task[Unit] =
-    Task.unsafeCreate { (context, cb) =>
-      implicit val s = context.scheduler
-      asyncFileChannel.flush(writeMetaData, Callback.async(cb))
+    Task.create { (scheduler, cb) =>
+      implicit val s = scheduler
+      asyncFileChannel.flush(writeMetaData, Callback.forked(cb))
     }
 
   /** $closeDesc */

--- a/src/main/scala/monix/nio/file/TaskWatchService.scala
+++ b/src/main/scala/monix/nio/file/TaskWatchService.scala
@@ -1,10 +1,10 @@
 package monix.nio.file
 
 import java.nio.file.WatchEvent.Kind
-import java.nio.file.{Path, WatchKey}
+import java.nio.file.{ Path, WatchKey }
 
 import monix.eval.Task
-import monix.execution.{Callback, Scheduler}
+import monix.execution.{ Callback, Scheduler }
 
 import scala.concurrent.duration.TimeUnit
 

--- a/src/main/scala/monix/nio/file/TaskWatchService.scala
+++ b/src/main/scala/monix/nio/file/TaskWatchService.scala
@@ -1,10 +1,10 @@
 package monix.nio.file
 
 import java.nio.file.WatchEvent.Kind
-import java.nio.file.{ Path, WatchKey }
+import java.nio.file.{Path, WatchKey}
 
-import monix.eval.{ Callback, Task }
-import monix.execution.Scheduler
+import monix.eval.Task
+import monix.execution.{Callback, Scheduler}
 
 import scala.concurrent.duration.TimeUnit
 
@@ -22,23 +22,23 @@ abstract class TaskWatchService {
   protected val watchService: WatchService
 
   def poll(timeout: Long, timeUnit: TimeUnit): Task[Option[WatchKey]] = {
-    Task.unsafeCreate { (context, cb) =>
-      implicit val s = context.scheduler
-      watchService.poll(timeout, timeUnit, Callback.async(cb))
+    Task.create { (scheduler, cb) =>
+      implicit val s = scheduler
+      watchService.poll(timeout, timeUnit, Callback.forked(cb))
     }
   }
 
   def poll(): Task[Option[WatchKey]] = {
-    Task.unsafeCreate { (context, cb) =>
-      implicit val s = context.scheduler
-      watchService.poll(Callback.async(cb))
+    Task.create { (scheduler, cb) =>
+      implicit val s = scheduler
+      watchService.poll(Callback.forked(cb))
     }
   }
 
   def take(): Task[WatchKey] = {
-    Task.unsafeCreate { (context, cb) =>
-      implicit val s = context.scheduler
-      watchService.take(Callback.async(cb))
+    Task.create { (scheduler, cb) =>
+      implicit val s = scheduler
+      watchService.take(Callback.forked(cb))
     }
   }
 

--- a/src/main/scala/monix/nio/file/WatchService.scala
+++ b/src/main/scala/monix/nio/file/WatchService.scala
@@ -1,13 +1,13 @@
 package monix.nio.file
 
-import java.nio.file.StandardWatchEventKinds.{ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY}
+import java.nio.file.StandardWatchEventKinds.{ ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY }
 import java.nio.file.WatchEvent.Kind
-import java.nio.file.{Path, WatchEvent, WatchKey}
+import java.nio.file.{ Path, WatchEvent, WatchKey }
 
 import com.sun.nio.file.SensitivityWatchEventModifier
-import monix.execution.{Callback, Cancelable, Scheduler}
+import monix.execution.{ Callback, Cancelable, Scheduler }
 
-import scala.concurrent.{Future, Promise}
+import scala.concurrent.{ Future, Promise }
 import scala.concurrent.duration.TimeUnit
 import scala.util.control.NonFatal
 

--- a/src/main/scala/monix/nio/tcp/AsyncServerSocketChannel.scala
+++ b/src/main/scala/monix/nio/tcp/AsyncServerSocketChannel.scala
@@ -1,13 +1,13 @@
 package monix.nio.tcp
 
-import java.net.{InetSocketAddress, StandardSocketOptions}
+import java.net.{ InetSocketAddress, StandardSocketOptions }
 import java.nio.channels.spi.AsynchronousChannelProvider
-import java.nio.channels.{AsynchronousChannelGroup, AsynchronousServerSocketChannel, AsynchronousSocketChannel, CompletionHandler}
+import java.nio.channels.{ AsynchronousChannelGroup, AsynchronousServerSocketChannel, AsynchronousSocketChannel, CompletionHandler }
 import java.util.concurrent.Executors
 
-import monix.execution.{Callback, Cancelable, Scheduler}
+import monix.execution.{ Callback, Cancelable, Scheduler }
 
-import scala.concurrent.{Future, Promise}
+import scala.concurrent.{ Future, Promise }
 import scala.util.control.NonFatal
 
 /**

--- a/src/main/scala/monix/nio/tcp/AsyncServerSocketChannel.scala
+++ b/src/main/scala/monix/nio/tcp/AsyncServerSocketChannel.scala
@@ -1,14 +1,13 @@
 package monix.nio.tcp
 
-import java.net.{ InetSocketAddress, StandardSocketOptions }
+import java.net.{InetSocketAddress, StandardSocketOptions}
 import java.nio.channels.spi.AsynchronousChannelProvider
-import java.nio.channels.{ AsynchronousChannelGroup, AsynchronousServerSocketChannel, AsynchronousSocketChannel, CompletionHandler }
+import java.nio.channels.{AsynchronousChannelGroup, AsynchronousServerSocketChannel, AsynchronousSocketChannel, CompletionHandler}
 import java.util.concurrent.Executors
 
-import monix.eval.Callback
-import monix.execution.{ Cancelable, Scheduler }
+import monix.execution.{Callback, Cancelable, Scheduler}
 
-import scala.concurrent.{ Future, Promise }
+import scala.concurrent.{Future, Promise}
 import scala.util.control.NonFatal
 
 /**
@@ -60,7 +59,7 @@ abstract class AsyncServerSocketChannel extends AutoCloseable {
     *
     * @param cb $callbackDesc
     */
-  def accept(cb: Callback[AsyncSocketChannel]): Unit
+  def accept(cb: Callback[Throwable, AsyncSocketChannel]): Unit
 
   /** $acceptDesc */
   def accept(): Future[AsyncSocketChannel] = {
@@ -119,15 +118,15 @@ object AsyncServerSocketChannel {
         Left(exc)
     }
 
-    private[this] val acceptHandler: CompletionHandler[AsynchronousSocketChannel, Callback[AsyncSocketChannel]] = {
-      new CompletionHandler[AsynchronousSocketChannel, Callback[AsyncSocketChannel]] {
-        override def completed(result: AsynchronousSocketChannel, attachment: Callback[AsyncSocketChannel]) =
+    private[this] val acceptHandler: CompletionHandler[AsynchronousSocketChannel, Callback[Throwable, AsyncSocketChannel]] = {
+      new CompletionHandler[AsynchronousSocketChannel, Callback[Throwable, AsyncSocketChannel]] {
+        override def completed(result: AsynchronousSocketChannel, attachment: Callback[Throwable, AsyncSocketChannel]) =
           attachment.onSuccess(new AsyncSocketChannel.NewIOImplementation(result))
-        override def failed(exc: Throwable, attachment: Callback[AsyncSocketChannel]) =
+        override def failed(exc: Throwable, attachment: Callback[Throwable, AsyncSocketChannel]) =
           attachment.onError(exc)
       }
     }
-    override def accept(cb: Callback[AsyncSocketChannel]): Unit = {
+    override def accept(cb: Callback[Throwable, AsyncSocketChannel]): Unit = {
       asynchronousServerSocketChannel.fold(_ => (), s => try s.accept(cb, acceptHandler) catch {
         case NonFatal(exc) =>
           cb.onError(exc)

--- a/src/main/scala/monix/nio/tcp/AsyncSocketChannel.scala
+++ b/src/main/scala/monix/nio/tcp/AsyncSocketChannel.scala
@@ -17,16 +17,16 @@
 
 package monix.nio.tcp
 
-import java.net.{InetSocketAddress, StandardSocketOptions}
+import java.net.{ InetSocketAddress, StandardSocketOptions }
 import java.nio.ByteBuffer
 import java.nio.channels.spi.AsynchronousChannelProvider
-import java.nio.channels.{AsynchronousChannelGroup, AsynchronousSocketChannel, CompletionHandler}
-import java.util.concurrent.{Executors, TimeUnit}
+import java.nio.channels.{ AsynchronousChannelGroup, AsynchronousSocketChannel, CompletionHandler }
+import java.util.concurrent.{ Executors, TimeUnit }
 
-import monix.execution.{Callback, Cancelable, Scheduler}
+import monix.execution.{ Callback, Cancelable, Scheduler }
 
 import scala.concurrent.duration.Duration
-import scala.concurrent.{Future, Promise}
+import scala.concurrent.{ Future, Promise }
 import scala.util.control.NonFatal
 
 /**

--- a/src/main/scala/monix/nio/tcp/AsyncSocketChannel.scala
+++ b/src/main/scala/monix/nio/tcp/AsyncSocketChannel.scala
@@ -17,17 +17,16 @@
 
 package monix.nio.tcp
 
-import java.net.{ InetSocketAddress, StandardSocketOptions }
+import java.net.{InetSocketAddress, StandardSocketOptions}
 import java.nio.ByteBuffer
 import java.nio.channels.spi.AsynchronousChannelProvider
-import java.nio.channels.{ AsynchronousChannelGroup, AsynchronousSocketChannel, CompletionHandler }
-import java.util.concurrent.{ Executors, TimeUnit }
+import java.nio.channels.{AsynchronousChannelGroup, AsynchronousSocketChannel, CompletionHandler}
+import java.util.concurrent.{Executors, TimeUnit}
 
-import monix.eval.Callback
-import monix.execution.{ Cancelable, Scheduler }
+import monix.execution.{Callback, Cancelable, Scheduler}
 
 import scala.concurrent.duration.Duration
-import scala.concurrent.{ Future, Promise }
+import scala.concurrent.{Future, Promise}
 import scala.util.control.NonFatal
 
 /**
@@ -80,7 +79,7 @@ abstract class AsyncSocketChannel extends AutoCloseable {
     * @param remote $remoteDesc
     * @param cb $callbackDesc
     */
-  def connect(remote: InetSocketAddress, cb: Callback[Unit]): Unit
+  def connect(remote: InetSocketAddress, cb: Callback[Throwable, Unit]): Unit
 
   /**
     * $connectDesc
@@ -106,7 +105,7 @@ abstract class AsyncSocketChannel extends AutoCloseable {
     * @param cb $callbackDesc . For this method it signals $readReturnDesc
     * @param timeout $timeout
     */
-  def read(dst: ByteBuffer, cb: Callback[Int], timeout: Option[Duration] = None): Unit
+  def read(dst: ByteBuffer, cb: Callback[Throwable, Int], timeout: Option[Duration] = None): Unit
 
   /**
     * $readDesc
@@ -129,7 +128,7 @@ abstract class AsyncSocketChannel extends AutoCloseable {
     * @param cb $callbackDesc . For this method it signals $writeReturnDesc
     * @param timeout $timeout
     */
-  def write(src: ByteBuffer, cb: Callback[Int], timeout: Option[Duration] = None): Unit
+  def write(src: ByteBuffer, cb: Callback[Throwable, Int], timeout: Option[Duration] = None): Unit
 
   /**
     * $writeDesc
@@ -179,14 +178,14 @@ object AsyncSocketChannel {
   private lazy val acg =
     AsynchronousChannelGroup.withCachedThreadPool(Executors.newCachedThreadPool(), -1)
 
-  private val connectHandler = new CompletionHandler[Void, Callback[Unit]] {
-    override def completed(result: Void, cb: Callback[Unit]) = cb.onSuccess(())
-    override def failed(exc: Throwable, cb: Callback[Unit]) = cb.onError(exc)
+  private val connectHandler = new CompletionHandler[Void, Callback[Throwable, Unit]] {
+    override def completed(result: Void, cb: Callback[Throwable, Unit]) = cb.onSuccess(())
+    override def failed(exc: Throwable, cb: Callback[Throwable, Unit]) = cb.onError(exc)
   }
 
-  private[this] val rwHandler = new CompletionHandler[Integer, Callback[Int]] {
-    override def completed(result: Integer, cb: Callback[Int]): Unit = cb.onSuccess(result)
-    override def failed(exc: Throwable, cb: Callback[Int]): Unit = cb.onError(exc)
+  private[this] val rwHandler = new CompletionHandler[Integer, Callback[Throwable, Int]] {
+    override def completed(result: Integer, cb: Callback[Throwable, Int]): Unit = cb.onSuccess(result)
+    override def failed(exc: Throwable, cb: Callback[Throwable, Int]): Unit = cb.onError(exc)
   }
 
   private[tcp] final case class NewIOImplementation(
@@ -226,7 +225,7 @@ object AsyncSocketChannel {
           }
       }
 
-    override def connect(remote: InetSocketAddress, cb: Callback[Unit]): Unit = {
+    override def connect(remote: InetSocketAddress, cb: Callback[Throwable, Unit]): Unit = {
       asyncSocketChannel.fold(_ => (), c => try c.connect(remote, cb, connectHandler) catch {
         case NonFatal(exc) =>
           cb.onError(exc)
@@ -249,7 +248,7 @@ object AsyncSocketChannel {
       })
     }
 
-    override def read(dst: ByteBuffer, cb: Callback[Int], timeout: Option[Duration]): Unit = {
+    override def read(dst: ByteBuffer, cb: Callback[Throwable, Int], timeout: Option[Duration]): Unit = {
       asyncSocketChannel.fold(_ => (), { c =>
         try {
           c.read(
@@ -265,7 +264,7 @@ object AsyncSocketChannel {
       })
     }
 
-    override def write(src: ByteBuffer, cb: Callback[Int], timeout: Option[Duration]): Unit = {
+    override def write(src: ByteBuffer, cb: Callback[Throwable, Int], timeout: Option[Duration]): Unit = {
       asyncSocketChannel.fold(_ => (), { c =>
         try {
           c.write(

--- a/src/main/scala/monix/nio/tcp/AsyncSocketChannelClient.scala
+++ b/src/main/scala/monix/nio/tcp/AsyncSocketChannelClient.scala
@@ -66,7 +66,7 @@ final class AsyncSocketChannelClient(
           scheduler.reportFailure(t)
           connectedSignal.failure(t)
         }
-        .runAsync
+        .runToFuture
     }
 
   private[this] lazy val asyncTcpClientObservable =

--- a/src/main/scala/monix/nio/tcp/AsyncSocketChannelConsumer.scala
+++ b/src/main/scala/monix/nio/tcp/AsyncSocketChannelConsumer.scala
@@ -19,7 +19,7 @@ package monix.nio.tcp
 
 import java.net.InetSocketAddress
 
-import monix.eval.{ Callback, Task }
+import monix.execution.Callback
 import monix.nio.AsyncChannelConsumer
 
 import scala.concurrent.Promise
@@ -55,7 +55,7 @@ final class AsyncSocketChannelConsumer private[tcp] (
     if (taskSocketChannel.isDefined) {
       connectedPromise.success(())
     } else {
-      val connectCallback = new Callback[Unit]() {
+      val connectCallback = new Callback[Throwable, Unit]() {
         override def onSuccess(value: Unit): Unit = {
           connectedPromise.success(())
         }

--- a/src/main/scala/monix/nio/tcp/AsyncSocketChannelObservable.scala
+++ b/src/main/scala/monix/nio/tcp/AsyncSocketChannelObservable.scala
@@ -19,7 +19,7 @@ package monix.nio.tcp
 
 import java.net.InetSocketAddress
 
-import monix.eval.Callback
+import monix.execution.Callback
 import monix.nio._
 import monix.reactive.observers.Subscriber
 
@@ -57,7 +57,7 @@ final class AsyncSocketChannelObservable private[tcp] (
     if (taskSocketChannel.isDefined) {
       connectedSignal.success(())
     } else {
-      val connectCallback = new Callback[Unit]() {
+      val connectCallback = new Callback[Throwable, Unit]() {
         override def onSuccess(value: Unit): Unit = {
           connectedSignal.success(())
         }

--- a/src/main/scala/monix/nio/tcp/TaskServerSocketChannel.scala
+++ b/src/main/scala/monix/nio/tcp/TaskServerSocketChannel.scala
@@ -2,8 +2,8 @@ package monix.nio.tcp
 
 import java.net.InetSocketAddress
 
-import monix.eval.{ Callback, Task }
-import monix.execution.Scheduler
+import monix.eval.Task
+import monix.execution.{Callback, Scheduler}
 
 /**
   * A `Task` based asynchronous channel for stream-oriented listening sockets.
@@ -47,9 +47,9 @@ abstract class TaskServerSocketChannel {
 
   /** $acceptDesc */
   def accept(): Task[TaskSocketChannel] =
-    Task.unsafeCreate { (context, cb) =>
-      implicit val s = context.scheduler
-      asyncServerSocketChannel.accept(new Callback[AsyncSocketChannel] {
+    Task.create { (scheduler, cb) =>
+      implicit val s = scheduler
+      asyncServerSocketChannel.accept(new Callback[Throwable, AsyncSocketChannel] {
         override def onError(ex: Throwable): Unit = cb.onError(ex)
         override def onSuccess(value: AsyncSocketChannel): Unit = cb.onSuccess(
           new TaskSocketChannel {

--- a/src/main/scala/monix/nio/tcp/TaskServerSocketChannel.scala
+++ b/src/main/scala/monix/nio/tcp/TaskServerSocketChannel.scala
@@ -3,7 +3,7 @@ package monix.nio.tcp
 import java.net.InetSocketAddress
 
 import monix.eval.Task
-import monix.execution.{Callback, Scheduler}
+import monix.execution.{ Callback, Scheduler }
 
 /**
   * A `Task` based asynchronous channel for stream-oriented listening sockets.

--- a/src/main/scala/monix/nio/tcp/TaskSocketChannel.scala
+++ b/src/main/scala/monix/nio/tcp/TaskSocketChannel.scala
@@ -3,7 +3,7 @@ package monix.nio.tcp
 import java.net.InetSocketAddress
 import java.nio.ByteBuffer
 
-import monix.eval.{ Callback, Task }
+import monix.eval.Task
 import monix.execution.Scheduler
 
 import scala.concurrent.duration.Duration
@@ -60,8 +60,8 @@ abstract class TaskSocketChannel {
     * @param remote $remoteDesc
     */
   def connect(remote: InetSocketAddress): Task[Unit] =
-    Task.unsafeCreate { (context, cb) =>
-      implicit val s = context.scheduler
+    Task.create { (scheduler, cb) =>
+      implicit val s = scheduler
       asyncSocketChannel.connect(remote, cb)
     }
 
@@ -84,8 +84,8 @@ abstract class TaskSocketChannel {
     * @return $readReturnDesc
     */
   def read(dst: ByteBuffer, timeout: Option[Duration] = None): Task[Int] =
-    Task.unsafeCreate { (context, cb) =>
-      implicit val s = context.scheduler
+    Task.create { (scheduler, cb) =>
+      implicit val s = scheduler
       asyncSocketChannel.read(dst, cb, timeout)
     }
 
@@ -98,8 +98,8 @@ abstract class TaskSocketChannel {
     * @return $writeReturnDesc
     */
   def write(src: ByteBuffer, timeout: Option[Duration] = None): Task[Int] =
-    Task.unsafeCreate { (context, cb) =>
-      implicit val s = context.scheduler
+    Task.create { (scheduler, cb) =>
+      implicit val s = scheduler
       asyncSocketChannel.write(src, cb, timeout)
     }
 

--- a/src/main/scala/monix/nio/udp/TaskDatagramChannel.scala
+++ b/src/main/scala/monix/nio/udp/TaskDatagramChannel.scala
@@ -64,7 +64,7 @@ abstract class TaskDatagramChannel {
     *
     * @param local $localDesc
     */
-  def bind(local: InetSocketAddress): Task[Unit] = Task {
+  def bind(local: InetSocketAddress): Task[Unit] = Task.evalAsync {
     asyncDatagramChannel.bind(local)
   }
 
@@ -80,7 +80,7 @@ abstract class TaskDatagramChannel {
     *
     * @return $receiveReturnDesc
     */
-  def receive(maxSize: Int, timeout: FiniteDuration): Task[Option[Packet]] = Task {
+  def receive(maxSize: Int, timeout: FiniteDuration): Task[Option[Packet]] = Task.evalAsync {
     asyncDatagramChannel.receive(maxSize, timeout)
   }
 
@@ -89,7 +89,7 @@ abstract class TaskDatagramChannel {
     *
     * @param packet $sendSrcDesc
     */
-  def send(packet: Packet): Task[Int] = Task {
+  def send(packet: Packet): Task[Int] = Task.evalAsync {
     asyncDatagramChannel.send(packet)
   }
 

--- a/src/test/scala/monix/nio/file/ChannelHandlingTest.scala
+++ b/src/test/scala/monix/nio/file/ChannelHandlingTest.scala
@@ -17,10 +17,10 @@
 
 package monix.nio.file
 
-import java.nio.file.{ Files, Paths }
+import java.nio.file.{Files, Paths}
 
 import minitest.TestSuite
-import monix.eval.Callback
+import monix.execution.Callback
 import monix.execution.atomic.Atomic
 import monix.execution.schedulers.TestScheduler
 
@@ -48,7 +48,7 @@ object ChannelHandlingTest extends TestSuite[TestScheduler] {
     val reader = new AsyncFileChannelObservable(readChannel, chunkSize)
     val consumer = new AsyncFileChannelConsumer(writeChannel)
 
-    reader.consumeWith(consumer).runAsync
+    reader.consumeWith(consumer).runToFuture
     s.tick()
     assert(readChannel.isClosed)
     assert(writeChannel.isClosed)
@@ -69,7 +69,7 @@ object ChannelHandlingTest extends TestSuite[TestScheduler] {
     val reader = new AsyncFileChannelObservable(readChannel, chunkSize)
     val consumer = new AsyncFileChannelConsumer(writeChannel)
 
-    val cancelable = reader.consumeWith(consumer).runAsync
+    val cancelable = reader.consumeWith(consumer).runToFuture
 
     //we need 3 ticks for a complete run of an elem
     tick(3)
@@ -112,7 +112,7 @@ object ChannelHandlingTest extends TestSuite[TestScheduler] {
     val consumer = new AsyncFileChannelConsumer(writeChannel)
 
     val callbackErrorCalled = Atomic(false)
-    val callback = new Callback[Long] {
+    val callback = new Callback[Throwable, Long] {
       override def onSuccess(value: Long): Unit = ()
 
       override def onError(ex: Throwable): Unit = callbackErrorCalled.set(true)
@@ -153,7 +153,7 @@ object ChannelHandlingTest extends TestSuite[TestScheduler] {
     val consumer = new AsyncFileChannelConsumer(writeChannel)
 
     val callbackErrorCalled = Atomic(false)
-    val callback = new Callback[Long] {
+    val callback = new Callback[Throwable, Long] {
       override def onSuccess(value: Long): Unit = ()
       override def onError(ex: Throwable): Unit = callbackErrorCalled.set(true)
     }

--- a/src/test/scala/monix/nio/file/ChannelHandlingTest.scala
+++ b/src/test/scala/monix/nio/file/ChannelHandlingTest.scala
@@ -17,7 +17,7 @@
 
 package monix.nio.file
 
-import java.nio.file.{Files, Paths}
+import java.nio.file.{ Files, Paths }
 
 import minitest.TestSuite
 import monix.execution.Callback

--- a/src/test/scala/monix/nio/file/ChannelHandlingTest.scala
+++ b/src/test/scala/monix/nio/file/ChannelHandlingTest.scala
@@ -33,6 +33,9 @@ object ChannelHandlingTest extends TestSuite[TestScheduler] {
       "TestScheduler should have no pending tasks")
   }
 
+  //we need these ticks for a complete run of an elem
+  private val ticksPerElem = 2
+
   def tick(n: Int)(implicit s: TestScheduler) = (1 to n) map (_ => s.tickOne())
 
   test("full parse") { implicit s =>
@@ -71,14 +74,12 @@ object ChannelHandlingTest extends TestSuite[TestScheduler] {
 
     val cancelable = reader.consumeWith(consumer).runToFuture
 
-    //we need 3 ticks for a complete run of an elem
-    tick(3)
+    tick(ticksPerElem)
     assertEquals(readChannel.getBytesReadPosition, 1)
     assertEquals(writeChannel.getBytesWritePosition, 1)
     assertEquals(writeTo.get.size, 1)
 
-    //we need 3 ticks for a complete run of an elem
-    tick(3)
+    tick(ticksPerElem)
 
     //check 2 reads have occurred
     assert(writeTo.get.size == 2)
@@ -119,8 +120,7 @@ object ChannelHandlingTest extends TestSuite[TestScheduler] {
     }
     reader.consumeWith(consumer).runAsync(callback)
 
-    //we need 3 ticks for a complete run of an elem
-    tick(3)
+    tick(ticksPerElem)
     assertEquals(readChannel.getBytesReadPosition, 1)
     assertEquals(writeChannel.getBytesWritePosition, 1)
     assertEquals(writeTo.get.size, 1)
@@ -159,8 +159,7 @@ object ChannelHandlingTest extends TestSuite[TestScheduler] {
     }
     reader.consumeWith(consumer).runAsync(callback)
 
-    //we need 3 ticks for a complete run of an elem
-    tick(3)
+    tick(ticksPerElem)
     assertEquals(readChannel.getBytesReadPosition, 1)
     assertEquals(writeChannel.getBytesWritePosition, 1)
     assertEquals(writeTo.get.size, 1)

--- a/src/test/scala/monix/nio/file/CodecTest.scala
+++ b/src/test/scala/monix/nio/file/CodecTest.scala
@@ -17,19 +17,19 @@
 
 package monix.nio.file
 
-import java.nio.file.{Files, Paths}
+import java.nio.file.{ Files, Paths }
 import java.util
 
 import minitest.SimpleTestSuite
 import monix.eval.Task
 import monix.execution.Callback
-import monix.execution.Scheduler.Implicits.{global => ctx}
+import monix.execution.Scheduler.Implicits.{ global => ctx }
 import monix.nio.file
-import monix.nio.text.UTF8Codec.{utf8Decode, utf8Encode}
+import monix.nio.text.UTF8Codec.{ utf8Decode, utf8Encode }
 import monix.reactive.Observable
 
 import scala.concurrent.duration._
-import scala.concurrent.{Await, Promise}
+import scala.concurrent.{ Await, Promise }
 
 object CodecTest extends SimpleTestSuite {
   test("decode file utf8") {

--- a/src/test/scala/monix/nio/file/CodecTest.scala
+++ b/src/test/scala/monix/nio/file/CodecTest.scala
@@ -17,25 +17,26 @@
 
 package monix.nio.file
 
-import java.nio.file.{ Files, Paths }
+import java.nio.file.{Files, Paths}
 import java.util
 
 import minitest.SimpleTestSuite
-import monix.eval.Callback
-import monix.execution.Scheduler.Implicits.{ global => ctx }
+import monix.eval.Task
+import monix.execution.Callback
+import monix.execution.Scheduler.Implicits.{global => ctx}
 import monix.nio.file
-import monix.nio.text.UTF8Codec.{ utf8Decode, utf8Encode }
+import monix.nio.text.UTF8Codec.{utf8Decode, utf8Encode}
 import monix.reactive.Observable
 
 import scala.concurrent.duration._
-import scala.concurrent.{ Await, Promise }
+import scala.concurrent.{Await, Promise}
 
 object CodecTest extends SimpleTestSuite {
   test("decode file utf8") {
     val from = Paths.get(this.getClass.getResource("/testFiles/specialChars.txt").toURI)
 
     val p = Promise[Seq[Byte]]()
-    val callback = new Callback[List[Array[Byte]]] {
+    val callback = new Callback[Throwable, List[Array[Byte]]] {
       override def onSuccess(value: List[Array[Byte]]): Unit = p.success(value.flatten)
       override def onError(ex: Throwable): Unit = p.failure(ex)
     }
@@ -57,11 +58,11 @@ object CodecTest extends SimpleTestSuite {
     for (grouping <- 1 to 12) {
       val obsSeq =
         Observable
-          .fromIterator(strSeq.flatMap(_.getBytes).grouped(grouping).map(_.toArray))
+          .fromIterator(Task(strSeq.flatMap(_.getBytes).grouped(grouping).map(_.toArray)))
           .pipeThrough(utf8Decode)
 
       val p = Promise[Boolean]()
-      val callback = new Callback[List[String]] {
+      val callback = new Callback[Throwable, List[String]] {
         override def onSuccess(value: List[String]): Unit = {
           p.success(if (value.mkString == strSeq.mkString) true else false)
         }
@@ -79,7 +80,7 @@ object CodecTest extends SimpleTestSuite {
     val to = Paths.get("src/test/resources/res.txt")
     val consumer = file.writeAsync(to)
     val p = Promise[Long]()
-    val callback = new Callback[Long] {
+    val callback = new Callback[Throwable, Long] {
       override def onSuccess(value: Long): Unit = p.success(value)
       override def onError(ex: Throwable): Unit = p.failure(ex)
     }

--- a/src/test/scala/monix/nio/file/FileChannelForTesting.scala
+++ b/src/test/scala/monix/nio/file/FileChannelForTesting.scala
@@ -20,7 +20,7 @@ package monix.nio.file
 import java.nio.ByteBuffer
 
 import monix.eval.Task
-import monix.execution.{Callback, Scheduler}
+import monix.execution.{ Callback, Scheduler }
 import monix.execution.atomic.Atomic
 import monix.nio.AsyncChannel
 

--- a/src/test/scala/monix/nio/file/IntegrationTest.scala
+++ b/src/test/scala/monix/nio/file/IntegrationTest.scala
@@ -17,7 +17,7 @@
 
 package monix.nio.file
 
-import java.nio.file.{Files, Paths, StandardOpenOption}
+import java.nio.file.{ Files, Paths, StandardOpenOption }
 import java.util
 
 import minitest.SimpleTestSuite
@@ -25,7 +25,7 @@ import monix.execution.Callback
 import monix.nio.file
 
 import scala.concurrent.duration._
-import scala.concurrent.{Await, Promise}
+import scala.concurrent.{ Await, Promise }
 import scala.util.control.NonFatal
 
 object IntegrationTest extends SimpleTestSuite {

--- a/src/test/scala/monix/nio/file/IntegrationTest.scala
+++ b/src/test/scala/monix/nio/file/IntegrationTest.scala
@@ -17,15 +17,15 @@
 
 package monix.nio.file
 
-import java.nio.file.{ Files, Paths, StandardOpenOption }
+import java.nio.file.{Files, Paths, StandardOpenOption}
 import java.util
 
 import minitest.SimpleTestSuite
-import monix.eval.Callback
+import monix.execution.Callback
 import monix.nio.file
 
 import scala.concurrent.duration._
-import scala.concurrent.{ Await, Promise }
+import scala.concurrent.{Await, Promise}
 import scala.util.control.NonFatal
 
 object IntegrationTest extends SimpleTestSuite {
@@ -36,7 +36,7 @@ object IntegrationTest extends SimpleTestSuite {
     val to = Paths.get("src/test/resources/out.txt")
     val consumer = file.writeAsync(to)
     val p = Promise[Boolean]()
-    val callback = new Callback[Long] {
+    val callback = new Callback[Throwable, Long] {
       override def onSuccess(value: Long): Unit = p.success(true)
       override def onError(ex: Throwable): Unit = p.failure(ex)
     }
@@ -68,7 +68,7 @@ object IntegrationTest extends SimpleTestSuite {
     }
     val consumer = file.appendAsync(to, Files.size(to))
     val p = Promise[Boolean]()
-    val callback = new Callback[Long] {
+    val callback = new Callback[Throwable, Long] {
       override def onSuccess(value: Long): Unit = p.success(true)
       override def onError(ex: Throwable): Unit = p.failure(ex)
     }

--- a/src/test/scala/monix/nio/file/WatchServiceTest.scala
+++ b/src/test/scala/monix/nio/file/WatchServiceTest.scala
@@ -16,7 +16,7 @@ object WatchServiceTest extends SimpleTestSuite {
     val path = Paths.get(System.getProperty("java.io.tmpdir"))
 
     val watchP = Promise[Boolean]()
-    val watchT = Task {
+    val watchT = Task.evalAsync {
       watchAsync(path).timeoutOnSlowUpstream(10.seconds).subscribe(
         (events: Array[WatchEvent[_]]) => {
           val captured = events.find(e => s"${e.kind().name()} - ${e.context().toString}".contains("monix"))
@@ -30,7 +30,7 @@ object WatchServiceTest extends SimpleTestSuite {
         err => watchP.failure(err),
         () => watchP.success(true))
     }
-    val fileT = Task {
+    val fileT = Task.evalAsync {
       val temp = File.createTempFile("monix", ".tmp", path.toFile)
       Thread.sleep(2000)
       temp.delete()

--- a/src/test/scala/monix/nio/file/WatchServiceTest.scala
+++ b/src/test/scala/monix/nio/file/WatchServiceTest.scala
@@ -36,8 +36,8 @@ object WatchServiceTest extends SimpleTestSuite {
       temp.delete()
     }
 
-    watchT.runAsync
-    fileT.runAsync
+    watchT.runToFuture
+    fileT.runToFuture
 
     val result = Await.result(watchP.future, 20.seconds)
     assert(result)

--- a/src/test/scala/monix/nio/udp/UdpIntegrationSpec.scala
+++ b/src/test/scala/monix/nio/udp/UdpIntegrationSpec.scala
@@ -30,7 +30,7 @@ object UdpIntegrationSpec extends SimpleTestSuite {
         packet.foreach(p => recv.append(new String(p.data)))
         packet
       }
-      .guaranteeCaseF(_ => readsPromise.success(recv.mkString))
+      .guaranteeCase(_ => Task(readsPromise.success(recv.mkString)))
       .subscribe(_.fold[Ack](Stop)(_ => Continue))
 
     val program = for {

--- a/src/test/scala/monix/nio/udp/UdpIntegrationSpec.scala
+++ b/src/test/scala/monix/nio/udp/UdpIntegrationSpec.scala
@@ -19,18 +19,18 @@ object UdpIntegrationSpec extends SimpleTestSuite {
 
     val writes = (ch: TaskDatagramChannel, to: InetSocketAddress) => Observable
       .fromIterable(data)
-      .mapTask(data => ch.send(Packet(data.getBytes, to)))
+      .mapEval(data => ch.send(Packet(data.getBytes, to)))
 
     val readsPromise = Promise[String]()
     val recv = new StringBuilder("")
     val reads = (ch: TaskDatagramChannel, maxSize: Int) => Observable
       .repeatEval(ch.receive(maxSize, 2.seconds))
-      .mapTask(t => t)
+      .mapEval(t => t)
       .map { packet =>
         packet.foreach(p => recv.append(new String(p.data)))
         packet
       }
-      .doOnTerminate(_ => readsPromise.success(recv.mkString))
+      .guaranteeCaseF(_ => readsPromise.success(recv.mkString))
       .subscribe(_.fold[Ack](Stop)(_ => Continue))
 
     val program = for {
@@ -43,7 +43,7 @@ object UdpIntegrationSpec extends SimpleTestSuite {
       _ <- ch.close()
     } yield sent == 40 & received == data.mkString("")
 
-    val result = Await.result(program.runAsync, 10.seconds)
+    val result = Await.result(program.runToFuture, 10.seconds)
     assert(result)
   }
 }


### PR DESCRIPTION
The Monix dependency was upgraded to Monix' latest version. This includes a breaking change in Monix (https://github.com/monix/monix/pull/670), where the Task behaviour for parallelism was changed. The Task.apply instances in monix-nio have been changed to Task.evalAsync to preserve the current behaviour.