### PR TITLE
allow building on JDK 14

### DIFF
--- a/src/main/scala/monix/nio/text/UTF8Codec.scala
+++ b/src/main/scala/monix/nio/text/UTF8Codec.scala
@@ -60,7 +60,7 @@ object UTF8Codec {
         subscriber.onError(APIContractViolationException(this.getClass.getName))
         Cancelable.empty
       } else {
-        remaining.put(0, 0)
+        remaining.put(0, 0: Byte)
         Cancelable(() => stopOnNext.set(true))
       }
     }


### PR DESCRIPTION
the `put` method used here acquired a new overload, causing
scalac to complain. this came up in the Scala community build.